### PR TITLE
Lilypond note calculation overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .project
 .settings
 Thumbs.db
+.vs

--- a/src/Data/Counter.py
+++ b/src/Data/Counter.py
@@ -71,20 +71,34 @@ class Counter(object):
     def matchesAlternative(self, beatStr):
         return any(beatStr == alt for alt in self._alternatives)
 
-
-_COUNTER_BEAT = Counter("")
+#1/4
+_QUARTER_COUNT = Counter("")
+#1/8
 _EIGHTH_COUNT = Counter("+", "&")
 _TRIPLET_COUNT = Counter("+a", "ea")
-_OLD_TRIPLET_COUNT = Counter("ea")
+_QUINTUPLET_COUNT = Counter("eaea")
+_SEPTUPLET_COUNT = Counter("e+ae+a")
+#1/16
 _SIXTEENTH_COUNT = Counter("e+a")
-_SIXTEENTH_COUNT_SPARSE = Counter(' + ')
-_SIXTEENTH_TRIPLETS = Counter('ea+ea')
-_SIXTEENTH_TRIPLETS_SPARSE = Counter('  +  ')
-_THIRTY_SECONDS_COUNT = Counter('.e.+.a.')
-_THIRTY_SECONDS_COUNT_SPARSE = Counter(' e + a ')
-_THIRTY_SECONDS_TRIPLET_COUNT = Counter('.e.a.+.e.a.')
-_THIRTY_SECONDS_TRIPLET_COUNT_SPARSE = Counter(' e a + e a ')
-
+_SIXTEENTH_COUNT_SPARSE = Counter(" + ")
+_SIXTEENTH_TRIPLETS_COUNT = Counter("ea+ea")
+_SIXTEENTH_TRIPLETS_COUNT_SPARSE = Counter("  +  ")
+_SIXTEENTH_QUINTUPLETS_COUNT = Counter("eaea+eaea")
+_SIXTEENTH_SEPTUPLETS_COUNT = Counter("e+ae+a+e+ae+a")
+#1/32
+_THIRTY_SECONDS_COUNT = Counter(".e.+.a.")
+_THIRTY_SECONDS_COUNT_SPARSE = Counter(" e + a ")
+_THIRTY_SECONDS_TRIPLET_COUNT = Counter(".e.a.+.e.a.")
+_THIRTY_SECONDS_TRIPLET_COUNT_SPARSE = Counter(" e a + e a ")
+_THIRTY_SECONDS_QUINTUPLETS_COUNT = Counter(".e.a.e.a.+.e.a.e.a.")
+_THIRTY_SECONDS_SEPTUPLETS_COUNT = Counter(".e.+.a.e.+.a.+.e.+.a.e.+.a.")
+#1/64
+_SIXTY_FOURTH_COUNT = Counter("'.'e'.'+'.'a'.'")
+_SIXTY_FOURTH_COUNT_SPARSE = Counter("   e   +   a   ")
+_SIXTY_FOURTH_TRIPLET_COUNT = Counter("'.'e'.'a'.'+'.'e'.'a'.'")
+_SIXTY_FOURTH_TRIPLET_COUNT_SPARSE = Counter("   e   a   +   e   a   ")
+_SIXTY_FOURTH_QUINTUPLETS_COUNT = Counter("'.'e'.'a'.'e'.'a'.'+'.'e'.'a'.'e'.'a'.'")
+_SIXTY_FOURTH_SEPTUPLETS_COUNT = Counter("'.'e'.'+'.'a'.'e'.'+'.'a'.'+'.'e'.'+'.'a'.'e'.'+'.'a'.'")
 
 class CounterRegistry(object):
     def __init__(self, defaults=True):
@@ -98,18 +112,34 @@ class CounterRegistry(object):
         self._counts = {}
 
     def restoreDefaults(self):
-        self.register('Quarter Notes', _COUNTER_BEAT)
+        #1/4
+        self.register('Quarter Notes', _QUARTER_COUNT)
+        #1/8
         self.register('8ths', _EIGHTH_COUNT)
         self.register('Triplets', _TRIPLET_COUNT)
+        self.register('Quintuplets', _QUINTUPLET_COUNT)
+        self.register('Septuplets', _SEPTUPLET_COUNT)
+        #1/16
         self.register('16ths', _SIXTEENTH_COUNT)
         self.register('Sparse 16ths', _SIXTEENTH_COUNT_SPARSE)
-        self.register('16th Triplets', _SIXTEENTH_TRIPLETS)
-        self.register('Sparse 16th Triplets', _SIXTEENTH_TRIPLETS_SPARSE)
+        self.register('16th Triplets', _SIXTEENTH_TRIPLETS_COUNT)
+        self.register('Sparse 16th Triplets', _SIXTEENTH_TRIPLETS_COUNT_SPARSE)
+        self.register('16th Quintuplets', _SIXTEENTH_QUINTUPLETS_COUNT)
+        self.register('16th Septuplets', _SIXTEENTH_SEPTUPLETS_COUNT)
+        #1/32
         self.register('32nds', _THIRTY_SECONDS_COUNT)
         self.register('Sparse 32nds', _THIRTY_SECONDS_COUNT_SPARSE)
         self.register('32nd Triplets', _THIRTY_SECONDS_TRIPLET_COUNT)
-        self.register('Sparse 32nd Triplets',
-                      _THIRTY_SECONDS_TRIPLET_COUNT_SPARSE)
+        self.register('Sparse 32nd Triplets', _THIRTY_SECONDS_TRIPLET_COUNT_SPARSE)
+        self.register('32nd Quintuplets', _THIRTY_SECONDS_QUINTUPLETS_COUNT)
+        self.register('32nd Septuplets', _THIRTY_SECONDS_SEPTUPLETS_COUNT)
+        #1/64
+        self.register('64ths', _SIXTY_FOURTH_COUNT)
+        self.register('Sparse 64ths', _SIXTY_FOURTH_COUNT_SPARSE)
+        self.register('64th Triplets', _SIXTY_FOURTH_TRIPLET_COUNT)
+        self.register('Sparse 64th Triplets', _SIXTY_FOURTH_TRIPLET_COUNT_SPARSE)
+        self.register('64th Quintuplets', _SIXTY_FOURTH_QUINTUPLETS_COUNT)
+        self.register('64th Septuplets', _SIXTY_FOURTH_SEPTUPLETS_COUNT)
 
     def register(self, name, count):
         if count in self._counts.values():

--- a/src/Data/Counter.py
+++ b/src/Data/Counter.py
@@ -23,8 +23,13 @@ Created on 16 Apr 2011
 
 '''
 
+from collections import OrderedDict
 from Data import DBConstants
 
+#thank some other thing I found online
+#Author: A.Polino
+def is_power2(num):
+	return num != 0 and ((num & (num - 1)) == 0)
 
 class Counter(object):
     '''A Counter represents a way of subdividing a single beat.
@@ -55,6 +60,27 @@ class Counter(object):
             if len(count) != len(counts):
                 raise ValueError("All counts for a Counter must be of the "
                                  "same length.")
+        self.noteDirectory = {
+            True: OrderedDict(),
+            False: OrderedDict()
+            }
+        #add all regular notes
+        i = 1
+        while len(self._counts) % i == 0:
+            self.noteDirectory[False][len(self._counts)/i] = i * 4
+            i *= 2
+
+        #If the counter isn't a power of two, it can contain compound notes
+        self.supportsCompound = not (len(self._counts) <= 2 or is_power2(len(self._counts)))
+
+        #If the beat is compound, add the compound notes (duh)
+        if self.supportsCompound:
+            j = 1
+            noteType = self.noteDirectory[False].values()[-1] * 2
+            while(j < len(self._counts)):
+                self.noteDirectory[True][j] = noteType
+                noteType /= 2
+                j *= 2
 
     def __iter__(self):
         return iter(self._counts)

--- a/src/Notation/lilypond.py
+++ b/src/Notation/lilypond.py
@@ -235,11 +235,14 @@ class LilyDuration(object):
             noteList.extend(calcComponentNotes(i))
         
         baseNote = max(noteList)
-        tupletLength = 0
+        tupletNoteCount = 0
         for i in noteList:
-            tupletLength += baseNote / i
+            tupletNoteCount += baseNote / i
+        tupletWholeNoteLength = baseNote
+        while(tupletWholeNoteLength > tupletNoteCount):
+            tupletWholeNoteLength /= 2
 
-        self.compoundStart = r"\tuplet {0}/{1} {{".format(tupletLength,baseNote/4)
+        self.compoundStart = r"\tuplet {0}/{1} {{".format(tupletNoteCount,tupletWholeNoteLength)
 
     def setCompoundEnd(self):
         self._compoundEnd = True

--- a/src/Notation/lilypond.py
+++ b/src/Notation/lilypond.py
@@ -107,69 +107,6 @@ class SevenTwelfthsProblem(BadNoteDuration):
 class ElevenTwelfthsProblem(BadNoteDuration):
     "DrumBurp cannot set notes of length 11/12 beat."
 
-
-def _getCompoundDuration(ticksInFullBeat, ticks, tickNum):
-    if ticks * 12 == ticksInFullBeat:  # 1/12
-        dur = LilyDuration("32", isCompound=True)
-    elif ticks * 6 == ticksInFullBeat:  # 2/12
-        dur = LilyDuration("16", isCompound=True)
-    elif ticks * 4 == ticksInFullBeat:  # 3/12
-        if (tickNum * 4) % ticksInFullBeat == 0:
-            dur = LilyDuration("16")
-        else:
-            dur = LilyDuration("16.", isCompound=True)
-    elif ticks * 3 == ticksInFullBeat:  # 4/12
-        dur = LilyDuration("8", isCompound=True)
-    elif ticks * 12 == 5 * ticksInFullBeat:  # 5/12
-        dur = LilyDuration("8", "32", isCompound=True)
-    elif ticks * 2 == ticksInFullBeat:  # 6/12
-        if (tickNum * 2) % ticksInFullBeat == 0:
-            dur = LilyDuration("8")
-        else:
-            dur = LilyDuration("8.", isCompound=True)
-    elif ticks * 12 == 7 * ticksInFullBeat:  # 7/12
-        dur = LilyDuration("8.", "32", isCompound=True)
-    elif ticks * 3 == 2 * ticksInFullBeat:  # 8/12
-        dur = LilyDuration("4", isCompound=True)
-    elif ticks * 4 == 3 * ticksInFullBeat:  # 9/12
-        if (tickNum * 4) % ticksInFullBeat == 0:
-            dur = LilyDuration("8.")
-        else:
-            dur = LilyDuration("4", "32", isCompound=True)
-    elif ticks * 6 == 5 * ticksInFullBeat:  # 10/12
-        dur = LilyDuration("4", "16", isCompound=True)
-    elif ticks * 12 == 11 * ticksInFullBeat:  # 11/12
-        dur = LilyDuration("4", "16.", isCompound=True)
-    else:
-        raise LilypondProblem("Note duration not recognised")
-    return dur
-
-
-def _getStraightDuration(ticksInFullBeat, ticks):
-    if 2 * ticks == ticksInFullBeat:
-        dur = LilyDuration("8")
-    elif 4 * ticks == ticksInFullBeat:
-        dur = LilyDuration("16")
-    elif 4 * ticks == 3 * ticksInFullBeat:
-        dur = LilyDuration("8.")
-    elif 8 * ticks == ticksInFullBeat:
-        dur = LilyDuration("32")
-    elif 8 * ticks == 3 * ticksInFullBeat:
-        dur = LilyDuration("16.")
-    elif 8 * ticks == 5 * ticksInFullBeat:
-        dur = LilyDuration("8", "32")
-    elif 8 * ticks == 7 * ticksInFullBeat:
-        dur = LilyDuration("8.", "32")
-    else:
-        raise LilypondProblem("Note duration not recognised")
-    return dur
-
-#thank based stackoverflow
-from functools import reduce
-
-def factors(n):    
-    return set(reduce(list.__add__, ([i, n//i] for i in range(1, int(n**0.5) + 1) if n % i == 0)))
-
 #thank some other thing I found online
 #Author: A.Polino
 def is_power2(num):

--- a/src/Notation/lilypond.py
+++ b/src/Notation/lilypond.py
@@ -296,9 +296,7 @@ class LilyMeasure(object):
         for direction in notes:
             eventTimes = [notePos.noteTime for (notePos, head_) in
                           notes[direction]]
-            #Prevents filling in the list with non existant notes
-            if(len(eventTimes) > 0):
-                noteTimes[direction] = self._calculateEventTimes(eventTimes)
+            noteTimes[direction] = self._calculateEventTimes(eventTimes)
         return noteTimes
 
     def _calculateEventDurations(self, timeList):

--- a/src/Notation/lilypond.py
+++ b/src/Notation/lilypond.py
@@ -145,8 +145,8 @@ def makeLilyDuration(beat, ticks, tickNum):
         noteType = sortedFactors[False].values()[-1] * 2
         while(j < ticksInFullBeat):
             sortedFactors[True][j] = noteType
-            noteType = noteType / 2
-            j = j * 2
+            noteType /= 2
+            j *= 2
 
     #check if the note length could be made up of any combination straight note(s). if it can't, it need to be compound.
     noteCompound = beatCompound and (not is_divisible_by(ticks, sortedFactors[False].keys()))
@@ -157,7 +157,7 @@ def makeLilyDuration(beat, ticks, tickNum):
         if(i <= ticks):
             note = i
             break
-    ticks = ticks - note
+    ticks -= note
     #if the remaining ticks are more than/equal to the next smallest note's ticks...
     #less than = only rest
     #equal = only dotted
@@ -165,31 +165,31 @@ def makeLilyDuration(beat, ticks, tickNum):
     dotted = False
     if(ticks > 0 and ticks >= note / 2):
         dotted = True
-        ticks = ticks - note / 2
+        ticks -= note / 2
 
     #find note again but for the rest length
     restNote = None
     for i in sorted(sortedFactors[noteCompound].keys(), reverse=True):
         if(i <= ticks):
             restNote = i
-            ticks = ticks - restNote
+            ticks -= restNote
             break
     #same but for dotted
     if not (restNote == None):
         restDotted = False
         if(ticks > 0 and ticks >= restNote / 2):
             restDotted = True
-            #ticks = ticks - note / 2
+            #ticks -= restNote / 2
     
     #Setting everything
     finalNote = str(sortedFactors[noteCompound][note])
     if(dotted):
-        finalNote = finalNote + "."
+        finalNote += "."
     finalRest = None
     if not restNote == None:
         finalRest = str(sortedFactors[noteCompound][restNote])
         if(restDotted):
-            finalRest = finalRest + "."
+            finalRest += "."
 
     dur = LilyDuration(finalNote,finalRest,noteCompound)
 

--- a/src/Notation/lilypond.py
+++ b/src/Notation/lilypond.py
@@ -107,11 +107,6 @@ class SevenTwelfthsProblem(BadNoteDuration):
 class ElevenTwelfthsProblem(BadNoteDuration):
     "DrumBurp cannot set notes of length 11/12 beat."
 
-#thank some other thing I found online
-#Author: A.Polino
-def is_power2(num):
-	return num != 0 and ((num & (num - 1)) == 0)
-
 def is_divisible_by(num, list):
     for i in list:
         if(num % i == 0):
@@ -125,35 +120,12 @@ def makeLilyDuration(beat, ticks, tickNum):
     dur = None
     ticksInFullBeat = beat.ticksPerBeat
     
-    from collections import OrderedDict
-    sortedFactors = {
-        True: OrderedDict(),
-        False: OrderedDict()
-        }
-    #add all regular notes
-    k = 1
-    while ticksInFullBeat % k == 0:
-        sortedFactors[False][ticksInFullBeat/k] = k * 4
-        k = k * 2
-
-    #If the beat isn't a power of two, it will contain compound notes
-    beatCompound = not (ticksInFullBeat <= 2 or is_power2(ticksInFullBeat))
-
-    #If the beat is compound, add the compound notes (duh)
-    if beatCompound:
-        j = 1
-        noteType = sortedFactors[False].values()[-1] * 2
-        while(j < ticksInFullBeat):
-            sortedFactors[True][j] = noteType
-            noteType /= 2
-            j *= 2
-
     #check if the note length could be made up of any combination straight note(s). if it can't, it need to be compound.
-    noteCompound = beatCompound and (not is_divisible_by(ticks, sortedFactors[False].keys()))
+    noteCompound = beat.counter.supportsCompound and (not is_divisible_by(ticks, beat.counter.noteDirectory[False].keys()))
     
     #find closest note (start at largest note in ticks, down to smallest)
     note = None
-    for i in sorted(sortedFactors[noteCompound].keys(), reverse=True):
+    for i in sorted(beat.counter.noteDirectory[noteCompound].keys(), reverse=True):
         if(i <= ticks):
             note = i
             break
@@ -169,7 +141,7 @@ def makeLilyDuration(beat, ticks, tickNum):
 
     #find note again but for the rest length
     restNote = None
-    for i in sorted(sortedFactors[noteCompound].keys(), reverse=True):
+    for i in sorted(beat.counter.noteDirectory[noteCompound].keys(), reverse=True):
         if(i <= ticks):
             restNote = i
             ticks -= restNote
@@ -182,12 +154,12 @@ def makeLilyDuration(beat, ticks, tickNum):
             #ticks -= restNote / 2
     
     #Setting everything
-    finalNote = str(sortedFactors[noteCompound][note])
+    finalNote = str(beat.counter.noteDirectory[noteCompound][note])
     if(dotted):
         finalNote += "."
     finalRest = None
     if not restNote == None:
-        finalRest = str(sortedFactors[noteCompound][restNote])
+        finalRest = str(beat.counter.noteDirectory[noteCompound][restNote])
         if(restDotted):
             finalRest += "."
 


### PR DESCRIPTION
I've wanted drumburp's lilypond export to have support for more note types for quite a while now, and here it finally is.
All the old hard-coded stuff has been replaced with an actual equation that (as far as I can tell) would work with any Counter.
I've also added a bunch of new counters: Quintuplets, Septuplets, and 64th notes.

A few things to note:
- The tuplet calculator doesn't reduce its fractions at all, so the numbers it produces can get a bit ridiculous... They are all "correct" though, and reducing them is well within the realm of possibility.
- ~~The majority of the code in makeLiliyDuration should probably be moved into the beat object to improve performance. The current code can get pretty slow for full songs...~~ Done.
- I'm not 100% satisfied with the actual text for the new Counters. If anyone has some better ways of counting them I'd love to see them!