### PR TITLE
Fixed tuplet rendering in lilypond

### DIFF
--- a/src/Data/Counter.py
+++ b/src/Data/Counter.py
@@ -25,6 +25,7 @@ Created on 16 Apr 2011
 
 from collections import OrderedDict
 from Data import DBConstants
+from math import log
 
 #thank some other thing I found online
 #Author: A.Polino
@@ -76,7 +77,8 @@ class Counter(object):
         #If the beat is compound, add the compound notes (duh)
         if self.supportsCompound:
             j = 1
-            noteType = self.noteDirectory[False].values()[-1] * 2
+            #nearest power of 2 (rounding down)
+            noteType = (1<<int(log(len(self._counts),2))) * 4
             while(j < len(self._counts)):
                 self.noteDirectory[True][j] = noteType
                 noteType /= 2

--- a/src/Notation/lilypond.py
+++ b/src/Notation/lilypond.py
@@ -32,6 +32,7 @@ import sys
 import os
 import subprocess
 import platform
+from math import log
 
 
 class LilyIndenter(object):
@@ -201,19 +202,19 @@ class LilyDuration(object):
                 nums.extend(calcComponentNotesFromStr(note.restTime))
             return nums
 
-        noteList = []
-        noteList.extend(calcComponentNotes(self))
+        notesInTuplet = []
+        notesInTuplet.extend(calcComponentNotes(self))
         for i in self._compoundList:
-            noteList.extend(calcComponentNotes(i))
+            notesInTuplet.extend(calcComponentNotes(i))
         
-        baseNote = max(noteList)
+        baseNote = max(notesInTuplet)
         tupletNoteCount = 0
-        for i in noteList:
+        for i in notesInTuplet:
             tupletNoteCount += baseNote / i
-        tupletWholeNoteLength = baseNote
-        while(tupletWholeNoteLength > tupletNoteCount):
-            tupletWholeNoteLength /= 2
-
+        
+        #nearest power of 2 (rounding down)
+        tupletWholeNoteLength = 1<<int(log(tupletNoteCount,2)) 
+            
         self.compoundStart = r"\tuplet {0}/{1} {{".format(tupletNoteCount,tupletWholeNoteLength)
 
     def setCompoundEnd(self):


### PR DESCRIPTION
As promised, here's the fix for tuplet rendering in lilypond.
Probably only applies to quintuplets/septuplets, triplets were never affected by this bug.